### PR TITLE
Add /add-flag skill and flags.json lint script

### DIFF
--- a/.claude/skills/add-flag/SKILL.md
+++ b/.claude/skills/add-flag/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: add-flag
+description: Add a new feature flag to flags.json via a series of prompts (key, title, description), then lint the file. Use when the user asks to add/create a new flag in this repo.
+---
+
+# Add a flag
+
+Walk the user through adding a new entry to `flags.json`, then validate the file.
+
+## Steps
+
+1. **Ask for the flag key.** Use `AskUserQuestion` (or a plain question if that tool
+   isn't available) to get a short kebab-case name describing what the flag toggles,
+   e.g. `payment-settings-v2`.
+   - If the user's answer already starts with `enable-`, use it as-is.
+   - Otherwise prefix it with `enable-`.
+   - Normalize to kebab-case (lowercase, spaces/underscores → hyphens). Reject
+     anything that doesn't match `^[a-z0-9]+(-[a-z0-9]+)*$` after normalization
+     and re-ask.
+   - Check the key doesn't already exist in `flags.json`. If it does, tell the
+     user and ask for a different name.
+
+2. **Ask for the title.** A short human-readable name for the flag (e.g. "Enable
+   Payment Settings V2"). Suggest a title-cased version of the key as a default.
+
+3. **Ask for the description.** What the flag does, when it should be used, and
+   any fallback behavior when disabled. This should be specific enough that
+   someone unfamiliar with the change understands the effect of toggling it —
+   see `README.md` for the convention.
+
+4. **Append the new entry to `flags.json`.** Read the file, add the new key at
+   the end (after the last existing key, preserving existing order and
+   4-space indentation), and write it back. Do not reorder or reformat
+   existing entries.
+
+5. **Run the lint script:**
+
+   ```
+   node scripts/lint-flags.js
+   ```
+
+   If it fails, fix the issue (most likely in the newly added entry) and
+   re-run until it passes. Report the result to the user.
+
+6. Show the user the diff (`git diff flags.json`) and stop — do not commit or
+   push unless the user separately asks for that.

--- a/.github/workflows/lint-flags.yml
+++ b/.github/workflows/lint-flags.yml
@@ -1,0 +1,23 @@
+name: Lint flags.json
+
+on:
+  push:
+    paths:
+      - flags.json
+      - scripts/lint-flags.js
+      - .github/workflows/lint-flags.yml
+  pull_request:
+    paths:
+      - flags.json
+      - scripts/lint-flags.js
+      - .github/workflows/lint-flags.yml
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - run: node scripts/lint-flags.js

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,10 @@
+# paypa-flags
+
+A public registry of feature flags loaded by PayPa Plane's extension at runtime (see README.md).
+
+## Adding a flag
+
+Use the `/add-flag` skill to add a new entry to `flags.json`. It prompts for the
+flag's key, title, and description, normalizes the key to kebab-case with an
+`enable-` prefix, appends the entry, and runs `scripts/lint-flags.js` to
+validate the file. Prefer this over hand-editing `flags.json`.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
 # paypa-flags
+
+A public registry of feature flags loaded by PayPa Plane's extension at runtime, so flags can be changed without rebuilding or resubmitting the app.
+
+## Structure
+
+Flags are defined in [`flags.json`](./flags.json) as a single JSON object keyed by flag name. Each flag has:
+
+- `title` — a short human-readable name for the flag
+- `description` — what the flag does and when it should be used
+
+Example:
+
+```json
+{
+    "enable-example-feature": {
+        "title": "Enable Example Feature",
+        "description": "Description of what this flag controls."
+    }
+}
+```
+
+## Adding a flag
+
+1. Add a new entry to `flags.json` using a `kebab-case` key prefixed with `enable-` (or another clear verb) describing what it toggles.
+2. Provide a concise `title` and a `description` that explains the effect of enabling the flag and any fallback behavior.
+3. Open a pull request for review.
+
+## Naming conventions
+
+- Use `enable-*` for flags that turn a feature on.
+- Keep descriptions specific about scope (e.g. which routes, components, or user types are affected) and any fallback behavior when disabled.

--- a/scripts/lint-flags.js
+++ b/scripts/lint-flags.js
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+// Validates flags.json conforms to the repo's flag conventions (see README.md).
+
+const fs = require("fs");
+const path = require("path");
+
+const FLAGS_PATH = path.join(__dirname, "..", "flags.json");
+
+// Pre-existing keys that predate the enable-* convention. Do not add new
+// entries here — new flags must use the enable- prefix.
+const LEGACY_PREFIX_EXCEPTIONS = new Set(["master-use-flags"]);
+
+const KEBAB_CASE = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+
+function fail(message) {
+  console.error(`lint-flags: ${message}`);
+  process.exitCode = 1;
+}
+
+function warn(message) {
+  console.warn(`lint-flags: warning: ${message}`);
+}
+
+const raw = fs.readFileSync(FLAGS_PATH, "utf8");
+
+let flags;
+try {
+  flags = JSON.parse(raw);
+} catch (err) {
+  fail(`flags.json is not valid JSON: ${err.message}`);
+  process.exit(1);
+}
+
+if (typeof flags !== "object" || flags === null || Array.isArray(flags)) {
+  fail("flags.json must be a single JSON object keyed by flag name.");
+  process.exit(1);
+}
+
+for (const [key, value] of Object.entries(flags)) {
+  if (!KEBAB_CASE.test(key)) {
+    fail(`"${key}" is not kebab-case.`);
+    continue;
+  }
+
+  if (!key.startsWith("enable-") && !LEGACY_PREFIX_EXCEPTIONS.has(key)) {
+    fail(`"${key}" must start with "enable-".`);
+  }
+
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    fail(`"${key}" must map to an object with "title" and "description".`);
+    continue;
+  }
+
+  const allowedFields = new Set(["title", "description"]);
+  for (const field of Object.keys(value)) {
+    if (!allowedFields.has(field)) {
+      warn(`"${key}" has unexpected field "${field}".`);
+    }
+  }
+
+  if (typeof value.title !== "string" || value.title.trim() === "") {
+    fail(`"${key}" is missing a non-empty "title".`);
+  }
+
+  if (typeof value.description !== "string" || value.description.trim() === "") {
+    fail(`"${key}" is missing a non-empty "description".`);
+  }
+}
+
+if (process.exitCode === 1) {
+  process.exit(1);
+}
+
+console.log(`lint-flags: OK (${Object.keys(flags).length} flags checked).`);


### PR DESCRIPTION
## Summary
- New `add-flag` Claude Code skill that prompts for a flag key, title, and description, normalizes the key to kebab-case with an `enable-` prefix, and appends it to `flags.json`
- New `scripts/lint-flags.js` that validates `flags.json`: valid JSON object, kebab-case keys, `enable-` prefix (with an allowlist for pre-existing exceptions like `master-use-flags`), and non-empty `title`/`description` on every entry
- The skill runs the lint script after appending and reports the result; it stops after showing the diff and does not commit/push on its own

## Test plan
- [x] `node scripts/lint-flags.js` passes against current `flags.json`
- [x] Verified it fails (non-zero exit) on a bad key (not kebab-case, missing `enable-` prefix, empty title)
- [x] Manually simulated the skill's append step and re-ran lint to confirm a valid new entry passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)